### PR TITLE
Add support for metrics and native histograms

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+    "extends": ["prettier"],
+    "plugins": ["prettier"],
+    "rules": {
+        "prettier/prettier": ["error"]
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 
 .idea
+
+dist

--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,0 +1,1 @@
+require: '@babel/register'

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# wavefront-metrics-sdk
+This is a plugin for metrics which adds Wavefront reporters via direct ingestion) and an abstraction that supports tagging at the host level. 
+
+### Setup
+$ npm install
+
+### Requirements
+NodeJS version 8
+
+### Usage
+* To run the example, run `npm run start <server> <token>`
+* To run with debugger, put `-r @babel/preset-env -r @babel/register -r regenerator-runtime` under the node parameters.
+*  `npm run build` to generate a UMD bundle under `dist` directory.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # wavefront-metrics-sdk
-This is a plugin for metrics which adds Wavefront reporters via direct ingestion) and an abstraction that supports tagging at the host level. 
+This is a plugin for metrics which adds Wavefront reporters via direct ingestion and an abstraction that supports tagging at the host level. 
 
 ### Setup
 $ npm install

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,17 @@
+module.exports = api => {
+  // Cache configuration is a required option
+  api.cache(false);
+
+  const presets = [
+    [
+      '@babel/preset-env',
+      {
+        useBuiltIns: false
+      }
+    ]
+  ];
+
+  const plugins = ['@babel/plugin-proposal-export-default-from'];
+
+  return { presets, plugins };
+};

--- a/example.js
+++ b/example.js
@@ -1,6 +1,6 @@
-const TaggedRegistry = require('./src/registry'),
-  WavefrontReporter = require('./src/wavefront-reporter'),
-  wavefrontHistogram = require('./src/wavefrontHistogram');
+import TaggedRegistry from './src/registry';
+import WavefrontReporter from './src/wavefront-reporter';
+import { wavefrontHistogram } from './src/wavefrontHistogram';
 
 // Metrics Reporting Function Example.
 function reportMetrics(server, token) {
@@ -29,7 +29,7 @@ function reportMetrics(server, token) {
   h.update(50);
 
   // wavefront histogram
-  let wf_h = wavefrontHistogram.wavefrontHistogram(reg, 'request.duration.wf', {
+  let wf_h = wavefrontHistogram(reg, 'request.duration.wf', {
     key1: 'val1'
   });
   wf_h.update(1.0);
@@ -47,4 +47,7 @@ function reportMetrics(server, token) {
   wfReporter.stop();
 }
 
-reportMetrics('test_server', 'test_token');
+if (process.argv.length !== 4) {
+  throw new Error(`Usage: node example.js <server> <token>`);
+}
+reportMetrics(process.argv[2], process.argv[3]);

--- a/example.js
+++ b/example.js
@@ -1,0 +1,50 @@
+const TaggedRegistry = require('./src/registry'),
+  WavefrontReporter = require('./src/wavefront-reporter'),
+  wavefrontHistogram = require('./src/wavefrontHistogram');
+
+// Metrics Reporting Function Example.
+function reportMetrics(server, token) {
+  // Create tagged registry and reporter
+  let reg = new TaggedRegistry();
+  let wfReporter = new WavefrontReporter({
+    server: server,
+    token: token,
+    source: 'wavefront-javascript-metrics',
+    registry: reg,
+    tags: { key1: 'val1', key2: 'val2' }
+  }).reportMinuteDistribution();
+  wfReporter.start(5000);
+
+  // counter
+  let c = reg.counter('request.counter', { key1: 'val1' });
+  c.inc();
+
+  // gauge
+  let g = reg.gauge('request.gauge', () => 2 + Math.random(), {
+    key1: 'val1'
+  });
+
+  // histogram
+  let h = reg.histogram('request.duration.foo', { key1: 'val1' });
+  h.update(50);
+
+  // wavefront histogram
+  let wf_h = wavefrontHistogram.wavefrontHistogram(reg, 'request.duration.wf', {
+    key1: 'val1'
+  });
+  wf_h.update(1.0);
+  wf_h.update(1.0);
+
+  // meter
+  let m = reg.meter('request.meter', { key1: 'val1' });
+  m.mark(1);
+
+  // timer
+  let t = reg.timer('request.timer', { key1: 'val1' });
+  t.update(50);
+
+  // stop the reporter
+  wfReporter.stop();
+}
+
+reportMetrics('test_server', 'test_token');

--- a/example.js
+++ b/example.js
@@ -1,6 +1,8 @@
-import TaggedRegistry from './src/registry';
-import WavefrontReporter from './src/wavefront-reporter';
-import { wavefrontHistogram } from './src/wavefrontHistogram';
+import {
+  TaggedRegistry,
+  WavefrontReporter,
+  registerHistogram
+} from './src/index';
 
 // Metrics Reporting Function Example.
 function reportMetrics(server, token) {
@@ -26,14 +28,15 @@ function reportMetrics(server, token) {
 
   // histogram
   let h = reg.histogram('request.duration.foo', { key1: 'val1' });
-  h.update(50);
+  h.update(1.0);
+  h.update(1.5);
 
   // wavefront histogram
-  let wf_h = wavefrontHistogram(reg, 'request.duration.wf', {
+  let wf_h = registerHistogram(reg, 'request.duration.wf', {
     key1: 'val1'
   });
   wf_h.update(1.0);
-  wf_h.update(1.0);
+  wf_h.update(2.0);
 
   // meter
   let m = reg.meter('request.meter', { key1: 'val1' });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1155 @@
+{
+  "name": "wavefront-nodejs-metrics-sdk",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha1-M+JZA9dIEYFTThLsCiXxa2/PQZ4=",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.8.3"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+      "integrity": "sha1-rVNWKn/Cmzuakbv30QOX/RRjRu0=",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha1-TptFzLgreWBycbKXmtgse2gWMHk=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=",
+      "dev": true
+    },
+    "acorn": {
+      "version": "7.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha1-41Zo3gtALzWd5RXFSCoaufiaab8=",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+      "integrity": "sha1-TGYGkXPW/daO2FI5/CViJhgrLr4=",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ajv/-/ajv-6.12.0.tgz",
+      "integrity": "sha1-BtYLlth7hFSlrauobnhU2mKdtLc=",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "4.3.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+      "integrity": "sha1-pcR8xDGB8fOP/XB2g3cA05VSKmE=",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.11.0"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha1-l6vwhyMQ/tiKXEZrJWgVdhReM/E=",
+          "dev": true
+        }
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha1-OIU59VF5vzkznIGvMKZU1p+Hy3U=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha1-bIw/uCfdQ+45GPJ7gngqt2WKb9k=",
+      "dev": true
+    },
+    "babel": {
+      "version": "6.23.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/babel/-/babel-6.23.0.tgz",
+      "integrity": "sha1-0NHn2APpdHZb7qMjLU4VPA77kPQ=",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^3.1.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha1-rd6+rXKmV023g2OdyHoSF3OXOWE=",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "6.8.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha1-YiYtZylzn5J1cjgkMC+yJ8jJP/s=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.10.0",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^1.4.3",
+        "eslint-visitor-keys": "^1.1.0",
+        "espree": "^6.1.2",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^7.0.0",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.14",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.3",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^6.1.2",
+        "strip-ansi": "^5.2.0",
+        "strip-json-comments": "^3.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      }
+    },
+    "eslint-config-prettier": {
+      "version": "6.10.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz",
+      "integrity": "sha1-Ep757FddXdwOJpZnvwne/NiYZCo=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-plugin-prettier": {
+      "version": "3.1.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha1-Qy5aZnZmq4TOcvlFxy932Zalybo=",
+      "dev": true,
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "5.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/eslint-scope/-/eslint-scope-5.0.0.tgz",
+      "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.4.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/eslint-utils/-/eslint-utils-1.4.3.tgz",
+      "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
+      "dev": true
+    },
+    "espree": {
+      "version": "6.2.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/espree/-/espree-6.2.1.tgz",
+      "integrity": "sha1-d/xy4f10SiBSwg84pbV1gy6Cc0o=",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.1.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/esquery/-/esquery-1.2.0.tgz",
+      "integrity": "sha1-oBClGcAojyUws0BBJL+18C6Xl/4=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.0.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/estraverse/-/estraverse-5.0.0.tgz",
+          "integrity": "sha1-rIF1C0gsEcyibksH6D7Y91+83CI=",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "3.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+      "integrity": "sha1-VFFFB3xQFJHjOxXsQIwpQ3bpSuQ=",
+      "dev": true
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha1-c+4RmC2Gyq95WYKNUZz+kn+sXwM=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha1-h0v2nG9ATCtdmcSBNBOZ/VWJJjM=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "3.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/figures/-/figures-3.2.0.tgz",
+      "integrity": "sha1-YlwYvSk8YE3EqN2y/r8MiDQXRq8=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha1-yg9u+m3T1WEzP7FFFQZcL6/fQ5w=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha1-XSltbwS9pEpGMKMBQTvbwuwIXsA=",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha1-ngm/cSs2CrkiXoEgSPcf3pyJZXs=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha1-oYgTV2pBsAokqX5/gVkYwuGZJfg=",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
+      }
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha1-dQ49tYYgh7RzfrrIIH/9HvJ7Jfw=",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "7.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/inquirer/-/inquirer-7.1.0.tgz",
+      "integrity": "sha1-EpigGFmIPhfHJkuChwrhA0+S3Sk=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^3.0.0",
+        "cli-cursor": "^3.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
+        "run-async": "^2.4.0",
+        "rxjs": "^6.5.3",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha1-lEdx/ZyByBJlxNaUGGDaBrtZR5s=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
+      "dev": true
+    },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.8",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "5.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^2.1.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/optionator/-/optionator-0.8.3.tgz",
+      "integrity": "sha1-hPodA2/p08fiHZmIS2ARZ+yPtJU=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.6",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "word-wrap": "~1.2.3"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha1-aR0nCeeMefrjoVZiJFLQB2LKqqI=",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha1-99f1/4qc2HKnvkyhQglZVqYHl8s=",
+      "dev": true
+    },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha1-0j1B/hN1ZG3i0BBNNFSjAIgCz3s=",
+      "dev": true,
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha1-SrzYUq0y3Xuqv+m0DgCjbbXzkuY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
+      "dev": true,
+      "requires": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.4.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/run-async/-/run-async-2.4.0.tgz",
+      "integrity": "sha1-5ZBUpbhods+uB/Qx0Yy63cWU8eg=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.5.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rxjs/-/rxjs-6.5.5.tgz",
+      "integrity": "sha1-xciE4wlMjP7jG/J+uH5UzPyH+ew=",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
+      "dev": true
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha1-ys12k0YaY3pXiNkqfdT7oGjoFjY=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha1-lSGCxGzHssMT0VluYjmSvRY7crU=",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha1-CxVx3XZpzNTz4G4U7x7tJiJa5TI=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+          "dev": true
+        }
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+      "integrity": "sha1-hXE5dakfuHvxswXMp3OV5A0qZKc=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.4.6",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/table/-/table-5.4.6.tgz",
+      "integrity": "sha1-EpLRlQDOP4YFOwXw6Ofko7shB54=",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.11.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/tslib/-/tslib-1.11.1.tgz",
+      "integrity": "sha1-6xXRKIJ/vuKEFUnhcfRe0zisfjU=",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
+      "dev": true
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "v8-compile-cache": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
+      "integrity": "sha1-4U3jezGm0ZT1aQ1n78Tn9vxqsw4=",
+      "dev": true
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/write/-/write-1.0.3.tgz",
+      "integrity": "sha1-CADhRSO5I6OH5BUSPIZWFqrg9cM=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,299 @@
         "@babel/highlight": "^7.8.3"
       }
     },
+    "@babel/compat-data": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/compat-data/-/compat-data-7.9.0.tgz",
+      "integrity": "sha1-BIFVVvyQsMF0q9LAwbuWb6oDamw=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.9.1",
+        "invariant": "^2.2.4",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/core": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/core/-/core-7.9.0.tgz",
+      "integrity": "sha1-rJd7U4t34TL/cG87ik260JwDxW4=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.0",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helpers": "^7.9.0",
+        "@babel/parser": "^7.9.0",
+        "@babel/template": "^7.8.6",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.1",
+        "json5": "^2.1.2",
+        "lodash": "^4.17.13",
+        "resolve": "^1.3.2",
+        "semver": "^5.4.1",
+        "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/generator": {
+      "version": "7.9.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/generator/-/generator-7.9.5.tgz",
+      "integrity": "sha1-J/CRd0GsxB5uqs7W1o+Ww/qa+vk=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.9.5",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.13",
+        "source-map": "^0.5.0"
+      }
+    },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz",
+      "integrity": "sha1-YLwLxlf2Ogkk/5pLSgskoTz03u4=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-builder-binary-assignment-operator-visitor": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.8.3.tgz",
+      "integrity": "sha1-yECXpCegYaxWocMOv1S3si0kFQM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-explode-assignable-expression": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-compilation-targets": {
+      "version": "7.8.7",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.8.7.tgz",
+      "integrity": "sha1-2sHuoVnA5L1G4wm1obBKZrU8Hd4=",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.8.6",
+        "browserslist": "^4.9.1",
+        "invariant": "^2.2.4",
+        "levenary": "^1.1.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/helper-create-regexp-features-plugin": {
+      "version": "7.8.8",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.8.8.tgz",
+      "integrity": "sha1-XYQYC1iPVgt4ZO+u6okkPlgxIIc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-regex": "^7.8.3",
+        "regexpu-core": "^4.7.0"
+      }
+    },
+    "@babel/helper-define-map": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-define-map/-/helper-define-map-7.8.3.tgz",
+      "integrity": "sha1-oGVcrVRRw3YLcm66h18c2PqgLBU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/types": "^7.8.3",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-explode-assignable-expression": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.8.3.tgz",
+      "integrity": "sha1-pyjcW06J4w/C38fQT6KKkwZT+YI=",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.9.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+      "integrity": "sha1-K1OCDTUnUSDhh0qC5aq+E3aSClw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.9.5"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+      "integrity": "sha1-uJS5R70AQ4HOY+odufCFR+kgq9U=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-hoist-variables": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-hoist-variables/-/helper-hoist-variables-7.8.3.tgz",
+      "integrity": "sha1-Hb6ba1XXjJtBg/yM3G4wzrg7cTQ=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-member-expression-to-functions": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+      "integrity": "sha1-ZZtxBJjqbB2ZB+DHPyBu7n2twkw=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-imports": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+      "integrity": "sha1-f+OVibOcAWMxtrjD9EHo8LFBlJg=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-module-transforms": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+      "integrity": "sha1-Q7NN/hWWGRhwfSRzJ0MTiOn+luU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-simple-access": "^7.8.3",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/template": "^7.8.6",
+        "@babel/types": "^7.9.0",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-optimise-call-expression": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+      "integrity": "sha1-ftBxgT0Jx1KY708giVYAa2ER7Lk=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+      "integrity": "sha1-nqKTvhm6vA9S/4yoizTDYRsghnA=",
+      "dev": true
+    },
+    "@babel/helper-regex": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-regex/-/helper-regex-7.8.3.tgz",
+      "integrity": "sha1-E5dyYH1RuT8j7/5yEFsxnSpMaWU=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/helper-remap-async-to-generator": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.8.3.tgz",
+      "integrity": "sha1-JzxgDYub9QBhQsHjWIfVVcEu3YY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-wrap-function": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-replace-supers": {
+      "version": "7.8.6",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+      "integrity": "sha1-Wtp0T9WtcyA78dZ0WaJ9y6Z+/8g=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-member-expression-to-functions": "^7.8.3",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/traverse": "^7.8.6",
+        "@babel/types": "^7.8.6"
+      }
+    },
+    "@babel/helper-simple-access": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+      "integrity": "sha1-f4EJkotNq0ZUB2mGr1dSMd62Oa4=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+      "integrity": "sha1-ManzAHD5E2inGCzwX4MXgQZfx6k=",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.8.3"
+      }
+    },
     "@babel/helper-validator-identifier": {
       "version": "7.9.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
       "integrity": "sha1-rVNWKn/Cmzuakbv30QOX/RRjRu0=",
       "dev": true
+    },
+    "@babel/helper-wrap-function": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz",
+      "integrity": "sha1-nb2yu1XvFKqgH+jJm2Kb1TUthhA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.8.3",
+        "@babel/types": "^7.8.3"
+      }
+    },
+    "@babel/helpers": {
+      "version": "7.9.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helpers/-/helpers-7.9.2.tgz",
+      "integrity": "sha1-tCqBqBHx5zE7iMuorcZrPZrmwJ8=",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.8.3",
+        "@babel/traverse": "^7.9.0",
+        "@babel/types": "^7.9.0"
+      }
     },
     "@babel/highlight": {
       "version": "7.9.0",
@@ -30,11 +318,710 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/parser": {
+      "version": "7.9.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/parser/-/parser-7.9.4.tgz",
+      "integrity": "sha1-aKNeawMZu8AURlvkOCgwARPy8ug=",
+      "dev": true
+    },
+    "@babel/plugin-proposal-async-generator-functions": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.8.3.tgz",
+      "integrity": "sha1-utMpxnCzgliXIbJ1QMfSiGAcbm8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-remap-async-to-generator": "^7.8.3",
+        "@babel/plugin-syntax-async-generators": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.8.3.tgz",
+      "integrity": "sha1-OMT+VVdEgm6X4q6TCw+0zAfmYFQ=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-export-default-from": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.8.3.tgz",
+      "integrity": "sha1-TLfC/ertSQtg2b/T3Iog+B+cLnw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-export-default-from": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-json-strings": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.8.3.tgz",
+      "integrity": "sha1-2lIWsjipi1ih4F1oUhBLEPmnDWs=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha1-5FciU/3u1lzd7s/as/kor+sv1dI=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-numeric-separator": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.8.3.tgz",
+      "integrity": "sha1-XWdpQJaZ7Js7aGhM2BFs7f+Tutg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3"
+      }
+    },
+    "@babel/plugin-proposal-object-rest-spread": {
+      "version": "7.9.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz",
+      "integrity": "sha1-P9ZZETBth0YBTsDQz3jw45oUkRY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-transform-parameters": "^7.9.5"
+      }
+    },
+    "@babel/plugin-proposal-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha1-ne6WqxZQ7tiGRq6XNMoWesSpxck=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-optional-chaining": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.9.0.tgz",
+      "integrity": "sha1-MdsWsVTDnWuKZFKSRyuYOUwpKlg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+      }
+    },
+    "@babel/plugin-proposal-unicode-property-regex": {
+      "version": "7.8.8",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.8.8.tgz",
+      "integrity": "sha1-7jqV6QzcBP6M2S7DJ5+gF9aKDR0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.8",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha1-qYP7Gusuw/btBCohD2QOkOeG/g0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
+      "integrity": "sha1-Yr+Ysto80h1iYVT8lu5bPLaOrLM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-export-default-from": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.8.3.tgz",
+      "integrity": "sha1-8eVc6FAJFEKvS6nCVQEGA1sp1ng=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha1-AcohtmjNghjJ5kDLbdiMVBKyyWo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha1-Fn7XA2iIYIH3S1w2xlqIwDtm0ak=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-numeric-separator": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.8.3.tgz",
+      "integrity": "sha1-Dj+2Pgm+obEelkZyccgwgAfnxB8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha1-YOIl7cvZimQDMqLnLdPmbxr1WHE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha1-YRGiZbz7Ag6579D9/X0mQCue1sE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-optional-chaining": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
+      "integrity": "sha1-T2nCq5UWfgGAzVM2YT+MV4j31Io=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-top-level-await": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
+      "integrity": "sha1-Os3s5pXmsTqvV/wpHRqACVDHE5E=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.8.3.tgz",
+      "integrity": "sha1-gndsLtDNnhpJlW2uuJYCTJRzuLY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.8.3.tgz",
+      "integrity": "sha1-Qwj60NlAnXHq+5sabuNfnWS2QIY=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-remap-async-to-generator": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.8.3.tgz",
+      "integrity": "sha1-Q37sW3mbWFIHIISzrl72boNJ6KM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-block-scoping": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.8.3.tgz",
+      "integrity": "sha1-l9Ndq2aFekN8FmNYuR0JBQyGjzo=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "lodash": "^4.17.13"
+      }
+    },
+    "@babel/plugin-transform-classes": {
+      "version": "7.9.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.9.5.tgz",
+      "integrity": "sha1-gAWX3biu/CwpPtJ0WcH8yTWibCw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-define-map": "^7.8.3",
+        "@babel/helper-function-name": "^7.9.5",
+        "@babel/helper-optimise-call-expression": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.6",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "globals": "^11.1.0"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/plugin-transform-computed-properties": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.8.3.tgz",
+      "integrity": "sha1-ltDSi3985OtbEguy4OlDNDyG+Bs=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-destructuring": {
+      "version": "7.9.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.9.5.tgz",
+      "integrity": "sha1-csl89fOGBK6jq/O5NbDhex23alA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-dotall-regex": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.8.3.tgz",
+      "integrity": "sha1-w8bsXuYSXGmTxcvKINyGIanqem4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-duplicate-keys": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.8.3.tgz",
+      "integrity": "sha1-jRLfMJqlN/JyiZxWXqF2jihuIfE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-exponentiation-operator": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.8.3.tgz",
+      "integrity": "sha1-WBptf1aXDga/UVYM1k9elHtw17c=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-for-of": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.9.0.tgz",
+      "integrity": "sha1-DyYOJ9PinNG7MSjaXnbHYapsEI4=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-function-name": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.8.3.tgz",
+      "integrity": "sha1-J5NzyycyKqrWfCaD53bfxHGW7Ys=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-literals": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.8.3.tgz",
+      "integrity": "sha1-rvI5gj2RmU7Hto5VGTUl1229XcE=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-member-expression-literals": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.8.3.tgz",
+      "integrity": "sha1-lj/tS2IKx8v2Apx1VCQCn6OkBBA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-modules-amd": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.9.0.tgz",
+      "integrity": "sha1-GXVe5yGRLPW7BMB9UCgK80hO/vQ=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-commonjs": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.9.0.tgz",
+      "integrity": "sha1-4+cvTLybSiYOML4OpZvfWjl0iUA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-simple-access": "^7.8.3",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-systemjs": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.9.0.tgz",
+      "integrity": "sha1-6f1Gopb8keAJtk4H3aqG1vDt65A=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-hoist-variables": "^7.8.3",
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "babel-plugin-dynamic-import-node": "^2.3.0"
+      }
+    },
+    "@babel/plugin-transform-modules-umd": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.9.0.tgz",
+      "integrity": "sha1-6Qmsridv7CgPm4IaXzjh8ItIBpc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-transforms": "^7.9.0",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-named-capturing-groups-regex": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.8.3.tgz",
+      "integrity": "sha1-oqcr/6ICrA4tBQav0JOcXsvEjGw=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-new-target": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.8.3.tgz",
+      "integrity": "sha1-YMwq5m2FyVq1QOs0urtkNNTHDEM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-object-super": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.8.3.tgz",
+      "integrity": "sha1-67ah56hv+paFi9asAQLWWUQmFyU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-replace-supers": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-parameters": {
+      "version": "7.9.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.9.5.tgz",
+      "integrity": "sha1-FzsmV0b14Vsq/lJ+7aZbc2I6B5U=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-property-literals": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.8.3.tgz",
+      "integrity": "sha1-MxlDANhTnB7SjGKtUIe6OAe5gmM=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-regenerator": {
+      "version": "7.8.7",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.8.7.tgz",
+      "integrity": "sha1-Xkag3KK+4a2ChesFJ+arycN2cvg=",
+      "dev": true,
+      "requires": {
+        "regenerator-transform": "^0.14.2"
+      }
+    },
+    "@babel/plugin-transform-reserved-words": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.8.3.tgz",
+      "integrity": "sha1-mgY1rE5mXSmxYoN908xQdF398fU=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-shorthand-properties": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
+      "integrity": "sha1-KFRSFuAjqDLU06EYXtSSvP6sCMg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-spread": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.8.3.tgz",
+      "integrity": "sha1-nI/+gXD9+4ixFOy5ILgvtulf5eg=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-sticky-regex": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.8.3.tgz",
+      "integrity": "sha1-vnoSkPgdrnZ0dUUhmeH3bWF1sQA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/helper-regex": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-template-literals": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.8.3.tgz",
+      "integrity": "sha1-e/pHMrRV6mpDEwrcC6dn7A5AKoA=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-typeof-symbol": {
+      "version": "7.8.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.8.4.tgz",
+      "integrity": "sha1-7eQGIxXOCq+KZXqSCFjxovNfxBI=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-transform-unicode-regex": {
+      "version": "7.8.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
+      "integrity": "sha1-DO8247pz5cVyc+/7GC9GuRoeyq0=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-regexp-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/preset-env": {
+      "version": "7.9.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/preset-env/-/preset-env-7.9.5.tgz",
+      "integrity": "sha1-jdx2A5vEW3dLGeL8VI9oB9iokZ8=",
+      "dev": true,
+      "requires": {
+        "@babel/compat-data": "^7.9.0",
+        "@babel/helper-compilation-targets": "^7.8.7",
+        "@babel/helper-module-imports": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+        "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+        "@babel/plugin-proposal-json-strings": "^7.8.3",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-proposal-numeric-separator": "^7.8.3",
+        "@babel/plugin-proposal-object-rest-spread": "^7.9.5",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-proposal-optional-chaining": "^7.9.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
+        "@babel/plugin-syntax-async-generators": "^7.8.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+        "@babel/plugin-syntax-top-level-await": "^7.8.3",
+        "@babel/plugin-transform-arrow-functions": "^7.8.3",
+        "@babel/plugin-transform-async-to-generator": "^7.8.3",
+        "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+        "@babel/plugin-transform-block-scoping": "^7.8.3",
+        "@babel/plugin-transform-classes": "^7.9.5",
+        "@babel/plugin-transform-computed-properties": "^7.8.3",
+        "@babel/plugin-transform-destructuring": "^7.9.5",
+        "@babel/plugin-transform-dotall-regex": "^7.8.3",
+        "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+        "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+        "@babel/plugin-transform-for-of": "^7.9.0",
+        "@babel/plugin-transform-function-name": "^7.8.3",
+        "@babel/plugin-transform-literals": "^7.8.3",
+        "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+        "@babel/plugin-transform-modules-amd": "^7.9.0",
+        "@babel/plugin-transform-modules-commonjs": "^7.9.0",
+        "@babel/plugin-transform-modules-systemjs": "^7.9.0",
+        "@babel/plugin-transform-modules-umd": "^7.9.0",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+        "@babel/plugin-transform-new-target": "^7.8.3",
+        "@babel/plugin-transform-object-super": "^7.8.3",
+        "@babel/plugin-transform-parameters": "^7.9.5",
+        "@babel/plugin-transform-property-literals": "^7.8.3",
+        "@babel/plugin-transform-regenerator": "^7.8.7",
+        "@babel/plugin-transform-reserved-words": "^7.8.3",
+        "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+        "@babel/plugin-transform-spread": "^7.8.3",
+        "@babel/plugin-transform-sticky-regex": "^7.8.3",
+        "@babel/plugin-transform-template-literals": "^7.8.3",
+        "@babel/plugin-transform-typeof-symbol": "^7.8.4",
+        "@babel/plugin-transform-unicode-regex": "^7.8.3",
+        "@babel/preset-modules": "^0.1.3",
+        "@babel/types": "^7.9.5",
+        "browserslist": "^4.9.1",
+        "core-js-compat": "^3.6.2",
+        "invariant": "^2.2.2",
+        "levenary": "^1.1.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/preset-modules": {
+      "version": "0.1.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/preset-modules/-/preset-modules-0.1.3.tgz",
+      "integrity": "sha1-EyQrU7XvjIg8PPfd3VWzbOgPvHI=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
+        "@babel/plugin-transform-dotall-regex": "^7.4.4",
+        "@babel/types": "^7.4.4",
+        "esutils": "^2.0.2"
+      }
+    },
+    "@babel/register": {
+      "version": "7.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/register/-/register-7.9.0.tgz",
+      "integrity": "sha1-AkZO3ldUi927Xp9wXSY7fD9D1Is=",
+      "dev": true,
+      "requires": {
+        "find-cache-dir": "^2.0.0",
+        "lodash": "^4.17.13",
+        "make-dir": "^2.1.0",
+        "pirates": "^4.0.0",
+        "source-map-support": "^0.5.16"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.9.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/runtime/-/runtime-7.9.2.tgz",
+      "integrity": "sha1-2Q3wWDo6JS8JqqYZZlNnuuUY2wY=",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/template": {
+      "version": "7.8.6",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/template/-/template-7.8.6.tgz",
+      "integrity": "sha1-hrIq8V+CjfsIZHT5ZNzD45xDzis=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/parser": "^7.8.6",
+        "@babel/types": "^7.8.6"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.9.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/traverse/-/traverse-7.9.5.tgz",
+      "integrity": "sha1-bnxWtE4qxwEalIwh4oPd2dnbl6I=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.8.3",
+        "@babel/generator": "^7.9.5",
+        "@babel/helper-function-name": "^7.9.5",
+        "@babel/helper-split-export-declaration": "^7.8.3",
+        "@babel/parser": "^7.9.0",
+        "@babel/types": "^7.9.5",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.13"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "11.12.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/globals/-/globals-11.12.0.tgz",
+          "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.9.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/types/-/types-7.9.5.tgz",
+      "integrity": "sha1-iSMfgpFailZqcDs7IBM/c9prlEQ=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.9.5",
+        "lodash": "^4.17.13",
+        "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.9.5",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+          "integrity": "sha1-kJd6jm+/a0MafcMXUu7iM78FLYA=",
+          "dev": true
+        }
+      }
+    },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=",
       "dev": true
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha1-4Xfmme4bjCLSMXTKqnQiZEOJUJ8=",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.11.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@types/node/-/node-13.11.1.tgz",
+      "integrity": "sha1-SaKoPfnSbarOrTDQzMh2KxKNU8c=",
+      "dev": true
+    },
+    "@types/resolve": {
+      "version": "0.0.8",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@types/resolve/-/resolve-0.0.8.tgz",
+      "integrity": "sha1-8mB00jjgJlnjI84aE9BB7uKA4ZQ=",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "acorn": {
       "version": "7.1.1",
@@ -59,6 +1046,12 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM=",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "4.3.1",
@@ -92,6 +1085,16 @@
         "color-convert": "^1.9.0"
       }
     },
+    "anymatch": {
+      "version": "3.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/anymatch/-/anymatch-3.1.1.tgz",
+      "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      }
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/argparse/-/argparse-1.0.10.tgz",
@@ -100,6 +1103,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
+      "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -113,10 +1122,25 @@
       "integrity": "sha1-0NHn2APpdHZb7qMjLU4VPA77kPQ=",
       "dev": true
     },
+    "babel-plugin-dynamic-import-node": {
+      "version": "2.3.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz",
+      "integrity": "sha1-8A9Qe9qjw+P/bn5emNkKesq5b38=",
+      "dev": true,
+      "requires": {
+        "object.assign": "^4.1.0"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/binary-extensions/-/binary-extensions-2.0.0.tgz",
+      "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
       "dev": true
     },
     "brace-expansion": {
@@ -129,11 +1153,76 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+      "dev": true
+    },
+    "browserslist": {
+      "version": "4.11.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/browserslist/-/browserslist-4.11.1.tgz",
+      "integrity": "sha1-kvhV7ojW4FDn5zEdmHmSAU8aHxs=",
+      "dev": true,
+      "requires": {
+        "caniuse-lite": "^1.0.30001038",
+        "electron-to-chromium": "^1.3.390",
+        "node-releases": "^1.1.53",
+        "pkg-up": "^2.0.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
+    },
+    "builtin-modules": {
+      "version": "3.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/builtin-modules/-/builtin-modules-3.1.0.tgz",
+      "integrity": "sha1-qtl8FRMet2tltQ7yCOdYTNdqdIQ=",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "dev": true
+    },
+    "caniuse-lite": {
+      "version": "1.0.30001042",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz",
+      "integrity": "sha1-yR7CHsLScL1228LOJhJgwpK4yTw=",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/chai/-/chai-4.2.0.tgz",
+      "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.0",
+        "type-detect": "^4.0.5"
+      }
     },
     "chalk": {
       "version": "2.4.2",
@@ -152,6 +1241,28 @@
       "integrity": "sha1-kAlISfCTfy7twkJdDSip5fDLrZ4=",
       "dev": true
     },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "3.3.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/chokidar/-/chokidar-3.3.0.tgz",
+      "integrity": "sha1-EsBxRmjFWAD2WeJi1JYql/r1VKY=",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.1.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.2.0"
+      }
+    },
     "cli-cursor": {
       "version": "3.1.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -166,6 +1277,42 @@
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
+    },
+    "cliui": {
+      "version": "5.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
+      "dev": true,
+      "requires": {
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
     },
     "color-convert": {
       "version": "1.9.3",
@@ -182,11 +1329,50 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.7.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "integrity": "sha1-F6LLiC1/d9NJBYXizmxSRCSjpEI=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "core-js-compat": {
+      "version": "3.6.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/core-js-compat/-/core-js-compat-3.6.5.tgz",
+      "integrity": "sha1-KlHZpOJd/W5pAlGqgfmePAVIHxw=",
+      "dev": true,
+      "requires": {
+        "browserslist": "^4.8.5",
+        "semver": "7.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-7.0.0.tgz",
+          "integrity": "sha1-XzyjV2HkfgWyBsba/yz4FPAxa44=",
+          "dev": true
+        }
+      }
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -218,10 +1404,40 @@
         "ms": "^2.1.1"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
     "doctrine": {
@@ -233,11 +1449,47 @@
         "esutils": "^2.0.2"
       }
     },
+    "electron-to-chromium": {
+      "version": "1.3.408",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.408.tgz",
+      "integrity": "sha1-5qOiuPh8h139bhZQGr56KPB5u7M=",
+      "dev": true
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true
+    },
+    "es-abstract": {
+      "version": "1.17.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/es-abstract/-/es-abstract-1.17.5.tgz",
+      "integrity": "sha1-2MnR1myJgfuSAOIlHXme7pJ3Suk=",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-regex": "^1.0.5",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimleft": "^2.1.1",
+        "string.prototype.trimright": "^2.1.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -382,11 +1634,22 @@
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.6.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha1-UwSRQ/QMbrkYsjZx0f4yGfOhs2I=",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
+    },
+    "events": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/events/-/events-2.1.0.tgz",
+      "integrity": "sha1-KpoeGOYQbg6BKqnr1KgZs8KcC6U="
     },
     "external-editor": {
       "version": "3.1.0",
@@ -441,6 +1704,44 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
+    "find-cache-dir": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+      "integrity": "sha1-jQ+UzRP+Q8bHwmGg2GEVypGMBfc=",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^2.0.0",
+        "pkg-dir": "^3.0.0"
+      }
+    },
+    "find-up": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-2.1.0.tgz",
+      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+      "dev": true,
+      "requires": {
+        "locate-path": "^2.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
     "flat-cache": {
       "version": "2.0.1",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -450,6 +1751,17 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -464,10 +1776,41 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "fsevents": {
+      "version": "2.1.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/fsevents/-/fsevents-2.1.2.tgz",
+      "integrity": "sha1-TAofs0vGjlQ7S4Kp7Dkr+9qECAU=",
+      "dev": true,
+      "optional": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "dev": true
+    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "gensync": {
+      "version": "1.0.0-beta.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/gensync/-/gensync-1.0.0-beta.1.tgz",
+      "integrity": "sha1-WPQ2H/mH5f9uHnohCCeqNx6qwmk=",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
+      "dev": true
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stdin": {
@@ -508,10 +1851,37 @@
         "type-fest": "^0.8.1"
       }
     },
+    "growl": {
+      "version": "1.10.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/he/-/he-1.2.0.tgz",
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true
     },
     "iconv-lite": {
@@ -643,6 +2013,42 @@
         }
       }
     },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha1-YQ88ksk1nOHbYW5TgAjSP/NRWOY=",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
+    },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-callable/-/is-callable-1.1.5.tgz",
+      "integrity": "sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs=",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
+      "dev": true
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -664,17 +2070,68 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
+      "dev": true
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-regex/-/is-regex-1.0.5.tgz",
+      "integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "is-symbol": {
+      "version": "1.0.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.1"
+      }
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "jest-worker": {
+      "version": "24.9.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/jest-worker/-/jest-worker-24.9.0.tgz",
+      "integrity": "sha1-Xb/bWy0yLphWeJgjipaXvM5ns+U=",
+      "dev": true,
+      "requires": {
+        "merge-stream": "^2.0.0",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha1-B2Srxpxj1ayELdSGfo0CXogN+PM=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -692,6 +2149,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
+      "dev": true
+    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -704,6 +2167,30 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json5": {
+      "version": "2.1.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha1-d4kd6DQGTMy6gq54QrtrFKE+1/I=",
+      "dev": true
+    },
+    "levenary": {
+      "version": "1.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/levenary/-/levenary-1.1.1.tgz",
+      "integrity": "sha1-hCqe6Y0gdap/ru2+MmeekgX0b3c=",
+      "dev": true,
+      "requires": {
+        "leven": "^3.1.0"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/levn/-/levn-0.3.0.tgz",
@@ -714,11 +2201,71 @@
         "type-check": "~0.3.2"
       }
     },
+    "locate-path": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-2.0.0.tgz",
+      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+      "dev": true,
+      "requires": {
+        "p-locate": "^2.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "3.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/log-symbols/-/log-symbols-3.0.0.tgz",
+      "integrity": "sha1-86CFFqXeqJMzan3uFNGKHP2rd8Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2"
+      }
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha1-ce5R+nvkyuwaY4OffmgtgTLTDK8=",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "make-dir": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/make-dir/-/make-dir-2.1.0.tgz",
+      "integrity": "sha1-XwMQ4YuL6JjMBwCSlaMK5B6R5vU=",
+      "dev": true,
+      "requires": {
+        "pify": "^4.0.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "merge-stream": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "dev": true
+    },
+    "metrics": {
+      "version": "0.1.21",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/metrics/-/metrics-0.1.21.tgz",
+      "integrity": "sha1-49PG6N61J/GjxJ1kxQ5kPgUzisg=",
+      "requires": {
+        "events": "^2.0.0"
+      }
     },
     "mimic-fn": {
       "version": "2.1.0",
@@ -750,6 +2297,136 @@
         "minimist": "^1.2.5"
       }
     },
+    "mocha": {
+      "version": "7.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/mocha/-/mocha-7.1.1.tgz",
+      "integrity": "sha1-ifuzDQlCmEWxu4k6gwv1dxBJpEE=",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "3.2.3",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.3.0",
+        "debug": "3.2.6",
+        "diff": "3.5.0",
+        "escape-string-regexp": "1.0.5",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "3.0.0",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.3",
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.6",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.3.2",
+        "yargs-parser": "13.1.2",
+        "yargs-unparser": "1.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha1-OWCDLT8VdBCDQtr9OmezMsCWnfE=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.3",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/mkdirp/-/mkdirp-0.5.3.tgz",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/supports-color/-/supports-color-6.0.0.tgz",
+          "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ms/-/ms-2.1.2.tgz",
@@ -773,6 +2450,76 @@
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
       "dev": true
+    },
+    "node-environment-flags": {
+      "version": "1.0.6",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+      "integrity": "sha1-owrBNiH299Z0JgpU3t4EjDmCwIg=",
+      "dev": true,
+      "requires": {
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+          "dev": true
+        }
+      }
+    },
+    "node-modules-regexp": {
+      "version": "1.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz",
+      "integrity": "sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=",
+      "dev": true
+    },
+    "node-releases": {
+      "version": "1.1.53",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/node-releases/-/node-releases-1.1.53.tgz",
+      "integrity": "sha1-LYIb+kme18Xf/F4vKMiOeKCO4/Q=",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
+      "dev": true
+    },
+    "object-inspect": {
+      "version": "1.7.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/object-inspect/-/object-inspect-1.7.0.tgz",
+      "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -812,6 +2559,30 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-limit": {
+      "version": "1.3.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha1-uGvV8MJWkJEcdZD8v8IBDVSzzLg=",
+      "dev": true,
+      "requires": {
+        "p-try": "^1.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-2.0.0.tgz",
+      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+      "dev": true,
+      "requires": {
+        "p-limit": "^1.1.0"
+      }
+    },
+    "p-try": {
+      "version": "1.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-1.0.0.tgz",
+      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+      "dev": true
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/parent-module/-/parent-module-1.0.1.tgz",
@@ -820,6 +2591,12 @@
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -832,6 +2609,102 @@
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
+      "dev": true
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0=",
+      "dev": true
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
+      "dev": true
+    },
+    "pirates": {
+      "version": "4.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/pirates/-/pirates-4.0.1.tgz",
+      "integrity": "sha1-ZDqSyviUVm+RsrmG0sZpUKji+4c=",
+      "dev": true,
+      "requires": {
+        "node-modules-regexp": "^1.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "3.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/pkg-dir/-/pkg-dir-3.0.0.tgz",
+      "integrity": "sha1-J0kCDyOe2ZCIGx9xIQ1R62UjvqM=",
+      "dev": true,
+      "requires": {
+        "find-up": "^3.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+          "dev": true
+        }
+      }
+    },
+    "pkg-up": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -854,6 +2727,12 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "private": {
+      "version": "0.1.8",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/private/-/private-0.1.8.tgz",
+      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
+      "dev": true
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/progress/-/progress-2.0.3.tgz",
@@ -866,11 +2745,109 @@
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
+    "readdirp": {
+      "version": "3.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/readdirp/-/readdirp-3.2.0.tgz",
+      "integrity": "sha1-wwwzNSsSyW37S4lUIaSf1alZODk=",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.0.4"
+      }
+    },
+    "regenerate": {
+      "version": "1.4.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
+      "dev": true
+    },
+    "regenerate-unicode-properties": {
+      "version": "8.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/regenerate-unicode-properties/-/regenerate-unicode-properties-8.2.0.tgz",
+      "integrity": "sha1-5d5xEdZV57pgwFfb6f83yH5lzew=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha1-2Hih0JS0MG0QuQlkhLM+vVXiZpc=",
+      "dev": true
+    },
+    "regenerator-transform": {
+      "version": "0.14.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/regenerator-transform/-/regenerator-transform-0.14.4.tgz",
+      "integrity": "sha1-UmaFeJZRjRYWp4oEeTN6MOqXTMc=",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4",
+        "private": "^0.1.8"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
       "dev": true
+    },
+    "regexpu-core": {
+      "version": "4.7.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/regexpu-core/-/regexpu-core-4.7.0.tgz",
+      "integrity": "sha1-/L9FjFBDGwu3tF1pZ7gZLZHz2Tg=",
+      "dev": true,
+      "requires": {
+        "regenerate": "^1.4.0",
+        "regenerate-unicode-properties": "^8.2.0",
+        "regjsgen": "^0.5.1",
+        "regjsparser": "^0.6.4",
+        "unicode-match-property-ecmascript": "^1.0.4",
+        "unicode-match-property-value-ecmascript": "^1.2.0"
+      }
+    },
+    "regjsgen": {
+      "version": "0.5.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/regjsgen/-/regjsgen-0.5.1.tgz",
+      "integrity": "sha1-SPC/Gl6iBRlpKcDZeYtC0e2YRDw=",
+      "dev": true
+    },
+    "regjsparser": {
+      "version": "0.6.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/regjsparser/-/regjsparser-0.6.4.tgz",
+      "integrity": "sha1-p2n4aEMIQBpm6bUp0kNv9NBmYnI=",
+      "dev": true,
+      "requires": {
+        "jsesc": "~0.5.0"
+      },
+      "dependencies": {
+        "jsesc": {
+          "version": "0.5.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/jsesc/-/jsesc-0.5.0.tgz",
+          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "dev": true
+        }
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
+      "dev": true
+    },
+    "resolve": {
+      "version": "1.15.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/resolve/-/resolve-1.15.1.tgz",
+      "integrity": "sha1-J73N7/6vLWJEuVuw+fS0ZTRR8+g=",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
     },
     "resolve-from": {
       "version": "4.0.0",
@@ -889,12 +2866,75 @@
       }
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+      "version": "3.0.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "1.20.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rollup/-/rollup-1.20.0.tgz",
+      "integrity": "sha1-N5nkzS9IwKBo2Hr1dZVtjXLJRHo=",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "^12.7.2",
+        "acorn": "^7.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.35",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/@types/node/-/node-12.12.35.tgz",
+          "integrity": "sha1-HmGyJsFDgPQ4T3DP5JplwsVTrSs=",
+          "dev": true
+        }
+      }
+    },
+    "rollup-plugin-babel": {
+      "version": "4.4.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rollup-plugin-babel/-/rollup-plugin-babel-4.4.0.tgz",
+      "integrity": "sha1-0VvSWUZqnRrMvbL+L/8XxS0DCss=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "rollup-plugin-node-resolve": {
+      "version": "5.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz",
+      "integrity": "sha1-cw+T0Q7SAkc7H7VKWZen24xthSM=",
+      "dev": true,
+      "requires": {
+        "@types/resolve": "0.0.8",
+        "builtin-modules": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.11.1",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "rollup-plugin-uglify": {
+      "version": "6.0.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rollup-plugin-uglify/-/rollup-plugin-uglify-6.0.4.tgz",
+      "integrity": "sha1-ZaCVnZFYZifx5Gp9uWb9UE7GxOY=",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "jest-worker": "^24.0.0",
+        "serialize-javascript": "^2.1.2",
+        "uglify-js": "^3.4.9"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha1-cvKvB0i1kjZNvTOJ5gDlqURKNR4=",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
       }
     },
     "run-async": {
@@ -915,6 +2955,12 @@
         "tslib": "^1.9.0"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
+      "dev": true
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -925,6 +2971,18 @@
       "version": "6.3.0",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/semver/-/semver-6.3.0.tgz",
       "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "dev": true
+    },
+    "serialize-javascript": {
+      "version": "2.1.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+      "integrity": "sha1-7OxTsOAxe9yV73arcHS3OEeF+mE=",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "shebang-command": {
@@ -967,6 +3025,30 @@
         }
       }
     },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-support": {
+      "version": "0.5.16",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/source-map-support/-/source-map-support-0.5.16.tgz",
+      "integrity": "sha1-CuBp5/47p1OMZMmFFeNTOerFoEI=",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -993,6 +3075,48 @@
             "ansi-regex": "^5.0.0"
           }
         }
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha1-hYEqa4R6wAInD1gIFGBkyZX7aRM=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+      "integrity": "sha1-RAiqLl1t3QyagHObCH+8BnwDs8w=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimstart": "^1.0.0"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+      "integrity": "sha1-x28c7zDyG7rYr+uNsVEUls+w8qM=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5",
+        "string.prototype.trimend": "^1.0.0"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha1-FK9tnzSwU/fPyJty+PLuFLkDmlQ=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "strip-ansi": {
@@ -1085,6 +3209,21 @@
         "os-tmpdir": "~1.0.2"
       }
     },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "tslib": {
       "version": "1.11.1",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/tslib/-/tslib-1.11.1.tgz",
@@ -1100,10 +3239,53 @@
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
+      "dev": true
+    },
     "type-fest": {
       "version": "0.8.1",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha1-CeJJ696FHTseSNJ8EFREZn8XuD0=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.9.1",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/uglify-js/-/uglify-js-3.9.1.tgz",
+      "integrity": "sha1-pWpxyMqi02tVVswf1X3wGuNJFTk=",
+      "dev": true,
+      "requires": {
+        "commander": "~2.20.3"
+      }
+    },
+    "unicode-canonical-property-names-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+      "integrity": "sha1-JhmADEyCWADv3YNDr33Zkzy+KBg=",
+      "dev": true
+    },
+    "unicode-match-property-ecmascript": {
+      "version": "1.0.4",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+      "integrity": "sha1-jtKjJWmWG86SJ9Cc0/+7j+1fAgw=",
+      "dev": true,
+      "requires": {
+        "unicode-canonical-property-names-ecmascript": "^1.0.4",
+        "unicode-property-aliases-ecmascript": "^1.0.4"
+      }
+    },
+    "unicode-match-property-value-ecmascript": {
+      "version": "1.2.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.2.0.tgz",
+      "integrity": "sha1-DZH2AO7rMJaqlisdb8iIduZOpTE=",
+      "dev": true
+    },
+    "unicode-property-aliases-ecmascript": {
+      "version": "1.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.1.0.tgz",
+      "integrity": "sha1-3Vepn2IHvt/0Yoq++5TFDblByPQ=",
       "dev": true
     },
     "uri-js": {
@@ -1130,11 +3312,95 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
+      }
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha1-YQY29rH3A4kb00dxzLF/uTtHB5w=",
       "dev": true
+    },
+    "wrap-ansi": {
+      "version": "5.1.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
     },
     "wrappy": {
       "version": "1.0.2",
@@ -1149,6 +3415,119 @@
       "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
+      }
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.3.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/yargs/-/yargs-13.3.2.tgz",
+      "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
+      "dev": true,
+      "requires": {
+        "cliui": "^5.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.1.2"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+          "dev": true
+        },
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.1.2",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/yargs-parser/-/yargs-parser-13.1.2.tgz",
+      "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.6.0",
+      "resolved": "http://build-artifactory.eng.vmware.com/api/npm/npm/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha1-7yXCx2n/a9CeSw+dfGBfsnhG6p8=",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "wavefront-nodejs-metrics-sdk",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/wavefrontHQ/wavefront-nodejs-metrics-sdk.git"
+  },
+  "keywords": ["wavefront", "metrics", "javascript"],
+  "author": "yzheqing@vmware.com",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/wavefrontHQ/wavefront-nodejs-metrics-sdk/issues"
+  },
+  "homepage": "https://github.com/wavefrontHQ/wavefront-nodejs-metrics-sdk#readme"
+}

--- a/package.json
+++ b/package.json
@@ -20,9 +20,14 @@
   "homepage": "https://github.com/wavefrontHQ/wavefront-nodejs-metrics-sdk#readme",
   "devDependencies": {
     "babel": "^6.23.0",
+    "chai": "^4.2.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
+    "mocha": "^7.1.1",
     "prettier": "^1.19.1"
+  },
+  "dependencies": {
+    "metrics": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "rollup -c",
+    "start": "node -r @babel/preset-env -r @babel/register -r regenerator-runtime example.js",
     "lint": "eslint '**/*.js'",
     "lint:fix": "prettier-eslint '**/*.js' --write",
     "test": "mocha"
@@ -42,6 +43,7 @@
     "rollup-plugin-uglify": "^6.0.4"
   },
   "dependencies": {
-    "metrics": "latest"
+    "metrics": "latest",
+    "wavefront-sdk-javascript": "latest"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,10 +2,13 @@
   "name": "wavefront-nodejs-metrics-sdk",
   "version": "1.0.0",
   "description": "Wavefront Metrics SDK",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
+    "prebuild": "rimraf dist",
+    "build": "rollup -c",
     "lint": "eslint '**/*.js'",
-    "lint:fix": "prettier-eslint '**/*.js' --write"
+    "lint:fix": "prettier-eslint '**/*.js' --write",
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -19,13 +22,24 @@
   },
   "homepage": "https://github.com/wavefrontHQ/wavefront-nodejs-metrics-sdk#readme",
   "devDependencies": {
+    "@babel/core": "^7.9.0",
+    "@babel/plugin-proposal-export-default-from": "^7.8.3",
+    "@babel/preset-env": "^7.9.5",
+    "@babel/register": "^7.9.0",
+    "@babel/runtime": "^7.9.2",
     "babel": "^6.23.0",
     "chai": "^4.2.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-prettier": "^3.1.2",
     "mocha": "^7.1.1",
-    "prettier": "^1.19.1"
+    "prettier": "^1.19.1",
+    "regenerator-runtime": "^0.13.5",
+    "rimraf": "^3.0.2",
+    "rollup": "^1.20.0",
+    "rollup-plugin-babel": "^4.4.0",
+    "rollup-plugin-node-resolve": "^5.2.0",
+    "rollup-plugin-uglify": "^6.0.4"
   },
   "dependencies": {
     "metrics": "latest"

--- a/package.json
+++ b/package.json
@@ -1,20 +1,28 @@
 {
   "name": "wavefront-nodejs-metrics-sdk",
   "version": "1.0.0",
-  "description": "",
+  "description": "Wavefront Metrics SDK",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "eslint '**/*.js'",
+    "lint:fix": "prettier-eslint '**/*.js' --write"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/wavefrontHQ/wavefront-nodejs-metrics-sdk.git"
   },
-  "keywords": ["wavefront", "metrics", "javascript"],
+  "keywords": [],
   "author": "yzheqing@vmware.com",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/wavefrontHQ/wavefront-nodejs-metrics-sdk/issues"
   },
-  "homepage": "https://github.com/wavefrontHQ/wavefront-nodejs-metrics-sdk#readme"
+  "homepage": "https://github.com/wavefrontHQ/wavefront-nodejs-metrics-sdk#readme",
+  "devDependencies": {
+    "babel": "^6.23.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.1",
+    "eslint-plugin-prettier": "^3.1.2",
+    "prettier": "^1.19.1"
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,23 @@
+import resolve from 'rollup-plugin-node-resolve';
+import babel from 'rollup-plugin-babel';
+import { uglify } from 'rollup-plugin-uglify';
+
+export default {
+  input: 'src/index.js',
+  output: [
+    {
+      name: 'WavefrontMetricSDK',
+      file: 'dist/index.js',
+      format: 'umd'
+    }
+  ],
+  plugins: [
+    resolve({
+      jsnext: true,
+      main: true,
+      browser: true
+    }),
+    babel(),
+    uglify()
+  ]
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 export WavefrontReporter from './wavefront-reporter';
 export TaggedRegistry from './registry';
-export { WavefrontHistogram } from './wavefrontHistogram';
+export { WavefrontHistogram, registerHistogram } from './wavefrontHistogram';

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+export WavefrontReporter from './wavefront-reporter';
+export TaggedRegistry from './registry';
+export { WavefrontHistogram } from './wavefrontHistogram';

--- a/src/registry.js
+++ b/src/registry.js
@@ -2,12 +2,22 @@ import utils from './util';
 const metrics = require('metrics');
 const Report = metrics.Report;
 
+/**
+ * Tagged Metrics Registry.
+ */
 export default class TaggedRegistry extends Report {
   constructor() {
     super();
   }
 
-  // return metric if key exist, otherwise create a new one
+  /**
+   * Return metric if key exist, otherwise create a new one
+   * @param metricName
+   * @param tags
+   * @param construct
+   * @param supplier
+   * @returns {any | metrics.Meter | metrics.Timer | metrics.Counter | metrics.Histogram | metrics.Gauge|metrics.Metric}
+   */
   _getOrAddMetric(metricName, tags, construct, supplier = null) {
     let encodedName = utils.encodeKey(metricName, tags);
     let metric = this.getMetric(encodedName);
@@ -18,28 +28,106 @@ export default class TaggedRegistry extends Report {
     return metric;
   }
 
+  /**
+   * Get a counter based on a encoded key.
+   * @param key
+   * @param tags
+   * @returns metrics.Counter
+   */
   counter(key, tags = null) {
     return this._getOrAddMetric(key, tags, metrics.Counter);
   }
 
+  /**
+   * Get a gauge based on a encoded key.
+   * @param key
+   * @param supplier
+   * @param tags
+   * @returns metrics.Gauge
+   */
   gauge(key, supplier, tags = null) {
     return this._getOrAddMetric(key, tags, metrics.Gauge, supplier);
   }
 
+  /**
+   * Get a histogram based on a encoded key.
+   * @param key
+   * @param tags
+   * @returns metrics.Histogram
+   */
   histogram(key, tags = null) {
     return this._getOrAddMetric(key, tags, metrics.Histogram);
   }
 
+  /**
+   * Get a meter based on a encoded key.
+   * @param key
+   * @param tags
+   * @returns metrics.Meter
+   */
   meter(key, tags = null) {
     return this._getOrAddMetric(key, tags, metrics.Meter);
   }
 
+  /**
+   * Get a timer based on a encoded key.
+   * @param key
+   * @param tags
+   * @returns metrics.Timer
+   */
   timer(key, tags = null) {
     return this._getOrAddMetric(key, tags, metrics.Timer);
   }
 
+  /**
+   * Return True if given key matches any counters.
+   * @param key
+   * @param tags
+   * @returns {boolean}
+   */
+  hasCounter(key, tags = null) {
+    return this.getMetrics().counters.indexOf(utils.encodeKey(key, tags)) >= 0;
+  }
+
+  /**
+   * Return True if given key matches any histograms.
+   * @param key
+   * @param tags
+   * @returns {boolean}
+   */
   hasHistogram(key, tags = null) {
-    let encodedName = utils.encodeKey(key, tags);
-    return this.getMetrics().histograms.indexOf(encodedName) >= 0;
+    return (
+      this.getMetrics().histograms.indexOf(utils.encodeKey(key, tags)) >= 0
+    );
+  }
+
+  /**
+   * Return True if given key matches any gauges.
+   * @param key
+   * @param tags
+   * @returns {boolean}
+   */
+  hasGauge(key, tags = null) {
+    return this.getMetrics().gauges.indexOf(utils.encodeKey(key, tags)) >= 0;
+  }
+
+  /**
+   * Return True if given key matches any meters.
+   * @param key
+   * @param tags
+   * @returns {boolean}
+   */
+  hasMeter(key, tags = null) {
+    return this.getMetrics().meters.indexOf(utils.encodeKey(key, tags)) >= 0;
+  }
+
+  /**
+   * Return True if given key matches any timers.
+   * @param key
+   * @param tags
+   * @returns {boolean}
+   */
+  hasTimer(key, tags = null) {
+    return this.getMetrics().timers.indexOf(utils.encodeKey(key, tags)) >= 0;
   }
 }

--- a/src/registry.js
+++ b/src/registry.js
@@ -6,10 +6,6 @@ const Report = metrics.Report;
  * Tagged Metrics Registry.
  */
 export default class TaggedRegistry extends Report {
-  constructor() {
-    super();
-  }
-
   /**
    * Return metric if key exist, otherwise create a new one
    * @param metricName
@@ -19,11 +15,11 @@ export default class TaggedRegistry extends Report {
    * @returns {any | metrics.Meter | metrics.Timer | metrics.Counter | metrics.Histogram | metrics.Gauge|metrics.Metric}
    */
   _getOrAddMetric(metricName, tags, construct, supplier = null) {
-    let encodedName = utils.encodeKey(metricName, tags);
+    const encodedName = utils.encodeKey(metricName, tags);
     let metric = this.getMetric(encodedName);
     if (metric) return metric;
 
-    metric = supplier ? new construct(supplier) : new construct();
+    metric = new construct(supplier);
     this.addMetric(encodedName, metric);
     return metric;
   }

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,15 +1,16 @@
-const metrics = require('metrics'),
-  Report = metrics.Report,
-  Util = require('./util');
+import metrics from 'metrics';
+import utils from './util';
 
-class TaggedRegistry extends Report {
+const Report = metrics.Report;
+
+export default class TaggedRegistry extends Report {
   constructor() {
     super();
   }
 
   // return metric if key exist, otherwise create a new one
   _getOrAddMetric(metricName, tags, construct, supplier = null) {
-    let encodedName = Util.encodeKey(metricName, tags);
+    let encodedName = utils.encodeKey(metricName, tags);
     let metric = this.getMetric(encodedName);
     if (metric) return metric;
 
@@ -39,9 +40,7 @@ class TaggedRegistry extends Report {
   }
 
   hasHistogram(key, tags = null) {
-    let encodedName = Util.encodeKey(key, tags);
+    let encodedName = utils.encodeKey(key, tags);
     return this.getMetrics().histograms.indexOf(encodedName) >= 0;
   }
 }
-
-module.exports = TaggedRegistry;

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,0 +1,47 @@
+const metrics = require('metrics'),
+  Report = metrics.Report,
+  Util = require('./util');
+
+class TaggedRegistry extends Report {
+  constructor() {
+    super();
+  }
+
+  // return metric if key exist, otherwise create a new one
+  _getOrAddMetric(metricName, tags, construct, supplier = null) {
+    let encodedName = Util.encodeKey(metricName, tags);
+    let metric = this.getMetric(encodedName);
+    if (metric) return metric;
+
+    metric = supplier ? new construct(supplier) : new construct();
+    this.addMetric(encodedName, metric);
+    return metric;
+  }
+
+  counter(key, tags = null) {
+    return this._getOrAddMetric(key, tags, metrics.Counter);
+  }
+
+  gauge(key, supplier, tags = null) {
+    return this._getOrAddMetric(key, tags, metrics.Gauge, supplier);
+  }
+
+  histogram(key, tags = null) {
+    return this._getOrAddMetric(key, tags, metrics.Histogram);
+  }
+
+  meter(key, tags = null) {
+    return this._getOrAddMetric(key, tags, metrics.Meter);
+  }
+
+  timer(key, tags = null) {
+    return this._getOrAddMetric(key, tags, metrics.Timer);
+  }
+
+  hasHistogram(key, tags = null) {
+    let encodedName = Util.encodeKey(key, tags);
+    return this.getMetrics().histograms.indexOf(encodedName) >= 0;
+  }
+}
+
+module.exports = TaggedRegistry;

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,6 +1,5 @@
-import metrics from 'metrics';
 import utils from './util';
-
+const metrics = require('metrics');
 const Report = metrics.Report;
 
 export default class TaggedRegistry extends Report {

--- a/src/util.js
+++ b/src/util.js
@@ -1,13 +1,5 @@
 const tagSeparator = '-tags=';
 
-/**
- * Validate URL of server.
- * @param server
- */
-function validateUrl(server) {
-  // TODO
-}
-
 function isEmpty(value) {
   return (
     (typeof value == 'string' && !value.trim()) ||
@@ -42,7 +34,6 @@ function decodeKey(key) {
 }
 
 export default {
-  validateUrl,
   isEmpty,
   encodeKey,
   decodeKey

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,47 @@
+const tagSeparator = '-tags=';
+
+class Util {
+  /**
+   * Validate URL of server.
+   * @param server
+   */
+  static validateUrl(server) {
+    // TODO
+  }
+
+  static isEmpty(value) {
+    return (
+      (typeof value == 'string' && !value.trim()) ||
+      typeof value == 'undefined' ||
+      value === null
+    );
+  }
+
+  static encodeKey(metricName, tags) {
+    if (this.isEmpty(tags)) {
+      return metricName;
+    }
+    let tagsType = Object.prototype.toString.call(tags).slice(8, -1);
+    if (tagsType === 'Object') {
+      // Sort the tags based on their keys to avoid duplicate metrics
+      let tagsArray = Object.keys(tags)
+        .sort()
+        .map(key => [key, tags[key]]);
+      return metricName + tagSeparator + JSON.stringify(tagsArray);
+    }
+    throw new Error(
+      'Wrong Tags datatype sent to the API. Expected: Object. Actual: ' +
+        tagsType
+    );
+  }
+
+  static decodeKey(key) {
+    let [metricName, tags] = [key, null];
+    if (key.indexOf(tagSeparator) > -1) {
+      [metricName, tags] = key.split(tagSeparator);
+    }
+    return [metricName, tags];
+  }
+}
+
+module.exports = Util;

--- a/src/util.js
+++ b/src/util.js
@@ -12,13 +12,12 @@ function encodeKey(metricName, tags) {
   if (this.isEmpty(tags)) {
     return metricName;
   }
-  let tagsType = Object.prototype.toString.call(tags).slice(8, -1);
-  if (tagsType === 'Object') {
+  if (typeof tags === 'object') {
     // Sort the tags based on their keys to avoid duplicate metrics
     let tagsArray = Object.keys(tags)
       .sort()
       .map(key => [key, tags[key]]);
-    return metricName + tagSeparator + JSON.stringify(tagsArray);
+    return `${metricName}${tagSeparator}${JSON.stringify(tagsArray)}`;
   }
   throw new Error(
     'Wrong Tags datatype sent to the API. Expected: Object. Actual: ' + tagsType

--- a/src/util.js
+++ b/src/util.js
@@ -1,47 +1,49 @@
 const tagSeparator = '-tags=';
 
-class Util {
-  /**
-   * Validate URL of server.
-   * @param server
-   */
-  static validateUrl(server) {
-    // TODO
-  }
-
-  static isEmpty(value) {
-    return (
-      (typeof value == 'string' && !value.trim()) ||
-      typeof value == 'undefined' ||
-      value === null
-    );
-  }
-
-  static encodeKey(metricName, tags) {
-    if (this.isEmpty(tags)) {
-      return metricName;
-    }
-    let tagsType = Object.prototype.toString.call(tags).slice(8, -1);
-    if (tagsType === 'Object') {
-      // Sort the tags based on their keys to avoid duplicate metrics
-      let tagsArray = Object.keys(tags)
-        .sort()
-        .map(key => [key, tags[key]]);
-      return metricName + tagSeparator + JSON.stringify(tagsArray);
-    }
-    throw new Error(
-      'Wrong Tags datatype sent to the API. Expected: Object. Actual: ' +
-        tagsType
-    );
-  }
-
-  static decodeKey(key) {
-    let [metricName, tags] = [key, null];
-    if (key.indexOf(tagSeparator) > -1) {
-      [metricName, tags] = key.split(tagSeparator);
-    }
-    return [metricName, tags];
-  }
+/**
+ * Validate URL of server.
+ * @param server
+ */
+function validateUrl(server) {
+  // TODO
 }
 
-module.exports = Util;
+function isEmpty(value) {
+  return (
+    (typeof value == 'string' && !value.trim()) ||
+    typeof value == 'undefined' ||
+    value === null
+  );
+}
+
+function encodeKey(metricName, tags) {
+  if (this.isEmpty(tags)) {
+    return metricName;
+  }
+  let tagsType = Object.prototype.toString.call(tags).slice(8, -1);
+  if (tagsType === 'Object') {
+    // Sort the tags based on their keys to avoid duplicate metrics
+    let tagsArray = Object.keys(tags)
+      .sort()
+      .map(key => [key, tags[key]]);
+    return metricName + tagSeparator + JSON.stringify(tagsArray);
+  }
+  throw new Error(
+    'Wrong Tags datatype sent to the API. Expected: Object. Actual: ' + tagsType
+  );
+}
+
+function decodeKey(key) {
+  let [metricName, tags] = [key, null];
+  if (key.indexOf(tagSeparator) > -1) {
+    [metricName, tags] = key.split(tagSeparator);
+  }
+  return [metricName, tags];
+}
+
+export default {
+  validateUrl,
+  isEmpty,
+  encodeKey,
+  decodeKey
+};

--- a/src/wavefront-reporter.js
+++ b/src/wavefront-reporter.js
@@ -1,0 +1,153 @@
+const metrics = require('metrics');
+const ScheduledReporter = metrics.ScheduledReporter;
+const wavefrontSDK = require('../../wavefront-sdk-javascript/src/index');
+const Util = require('./util');
+const wavefrontHistogram = require('./wavefrontHistogram');
+
+const metricsFunctionMap = {
+  counter: [counter => ['', counter.count]],
+  gauge: [gauge => ['', gauge.value()]],
+  meter: [
+    meter => ['.count', meter.count],
+    meter => ['.mean_rate', meter.meanRate()],
+    meter => ['.m1_rate', meter.oneMinuteRate()],
+    meter => ['.m5_rate', meter.fiveMinuteRate()],
+    meter => ['.m15_rate', meter.fifteenMinuteRate()]
+  ],
+  timer: [
+    timer => ['.count', timer.count()],
+    timer => ['.mean_rate', timer.meanRate()],
+    timer => ['.m1_rate', timer.oneMinuteRate()],
+    timer => ['.m5_rate', timer.fiveMinuteRate()],
+    timer => ['.m15_rate', timer.fifteenMinuteRate()]
+  ],
+  histogram: [
+    h => ['.count', h.count],
+    h => ['.min', h.min],
+    h => ['.mean', h.mean()],
+    h => ['.max', h.max],
+    h => ['.stddev', h.stdDev()],
+    h => ['.p50', h.percentiles([0.5])[0.5]],
+    h => ['.p75', h.percentiles([0.75])[0.75]],
+    h => ['.p95', h.percentiles([0.95])[0.95]],
+    h => ['.p98', h.percentiles([0.98])[0.98]],
+    h => ['.p99', h.percentiles([0.99])[0.99]],
+    h => ['.p999', h.percentiles([0.999])[0.999]]
+  ]
+};
+
+class WavefrontReporter extends ScheduledReporter {
+  constructor({
+    server,
+    token,
+    source = 'wavefront-javascript-metrics',
+    registry = null,
+    reportingInterval = 1,
+    tags = null,
+    enableRuntimeMetrics = false
+  }) {
+    super(registry);
+    this.server = server;
+    this.source = source;
+    this.batchSize = 10000;
+    this.wavefrontClient = new wavefrontSDK.wavefrontClient({
+      server: Util.validateUrl(server),
+      token: token,
+      batchSize: this.batchSize,
+      flushIntervalSeconds: reportingInterval
+    });
+    this.histogramGranularity = new Set();
+    this.enableRuntimeMetrics = enableRuntimeMetrics;
+
+    this.flushCurrentHist = true;
+    this.tags = !Util.isEmpty(tags) ? tags : {};
+  }
+
+  /**
+   * Collect metrics from registry and report them to Wavefront.
+   * TODO: With option to include current minute bin of histogram.
+   */
+  report() {
+    // Get all the metrics
+    let allMetrics = this.getMetrics();
+    for (let metrics of [
+      allMetrics.counters,
+      allMetrics.gauges,
+      allMetrics.meters,
+      allMetrics.timers,
+      allMetrics.histograms
+    ]) {
+      if (metrics.length > 0) {
+        for (let m of metrics) {
+          let [metricName, tags] = this._decodeMetric(m);
+          // If Wavefront histogram, client send_distribution
+          if (m instanceof wavefrontHistogram.WavefrontHistogram) {
+            let distributions = m.getDistribution();
+            if (this.flushCurrentHist) {
+              distributions.push(m.getCurrentMinuteDistribution());
+            }
+            for (let dist of distributions) {
+              this.wavefrontClient.sendDistribution(
+                metricName,
+                dist.centroids,
+                this.histogramGranularity,
+                dist.timestamp,
+                this.source,
+                tags
+              );
+            }
+            continue;
+          }
+          // If metric, client send_metric
+          for (let f of metricsFunctionMap[m.type]) {
+            const [suffix, value] = f(m);
+            console.log(metricName + suffix + ': ' + value);
+            this.wavefrontClient.sendMetric(
+              metricName + suffix,
+              value,
+              Date.now(),
+              this.source,
+              tags
+            );
+          }
+        }
+      }
+    }
+  }
+
+  _decodeMetric(metric) {
+    const [metricName, metricTagsArray] = Util.decodeKey(metric.name);
+    const tagsArray = JSON.parse(metricTagsArray);
+    let metricTags = {};
+    if (tagsArray && tagsArray.length) {
+      tagsArray.forEach(([key, value]) => (metricTags[key] = value));
+    }
+    const tags = Object.assign({}, metricTags, this.tags);
+    return [metricName, tags];
+  }
+
+  /**
+   * Flush the data and close the wavefront client
+   */
+  stop() {
+    this.report();
+    this.wavefrontClient.close();
+  }
+
+  reportMinuteDistribution() {
+    this.histogramGranularity.add(wavefrontSDK.histogramGranularity.MINUTE);
+    return this;
+  }
+
+  reportHourDistribution() {
+    this.histogramGranularity.add(wavefrontSDK.histogramGranularity.HOUR);
+    return this;
+  }
+
+  reportDayDistribution() {
+    this.histogramGranularity.add(wavefrontSDK.histogramGranularity.DAY);
+    return this;
+  }
+}
+
+module.exports = WavefrontReporter;

--- a/src/wavefront-reporter.js
+++ b/src/wavefront-reporter.js
@@ -1,6 +1,6 @@
-import * as wavefrontSDK from '../../wavefront-sdk-javascript/src/index';
 import utils from './util';
 import { WavefrontHistogram } from './wavefrontHistogram';
+import * as wavefrontSDK from 'wavefront-sdk-javascript';
 const metrics = require('metrics');
 const ScheduledReporter = metrics.ScheduledReporter;
 
@@ -51,7 +51,7 @@ export default class WavefrontReporter extends ScheduledReporter {
     this.source = source;
     this.batchSize = 10000;
     this.wavefrontClient = new wavefrontSDK.WavefrontDirectClient({
-      server: utils.validateUrl(server),
+      server: server,
       token: token,
       batchSize: this.batchSize,
       flushIntervalSeconds: reportingInterval

--- a/src/wavefront-reporter.js
+++ b/src/wavefront-reporter.js
@@ -1,8 +1,7 @@
-import metrics from 'metrics';
 import * as wavefrontSDK from '../../wavefront-sdk-javascript/src/index';
 import utils from './util';
 import { WavefrontHistogram } from './wavefrontHistogram';
-
+const metrics = require('metrics');
 const ScheduledReporter = metrics.ScheduledReporter;
 
 const metricsFunctionMap = {

--- a/src/wavefront-reporter.js
+++ b/src/wavefront-reporter.js
@@ -105,7 +105,6 @@ export default class WavefrontReporter extends ScheduledReporter {
           // If metric, client send_metric
           for (let f of metricsFunctionMap[m.type]) {
             const [suffix, value] = f(m);
-            console.log(metricName + suffix + ': ' + value);
             this.wavefrontClient.sendMetric(
               metricName + suffix,
               value,
@@ -127,7 +126,7 @@ export default class WavefrontReporter extends ScheduledReporter {
   _decodeMetric(metric) {
     const [metricName, metricTagsArray] = utils.decodeKey(metric.name);
     const tagsArray = JSON.parse(metricTagsArray);
-    let metricTags = {};
+    const metricTags = {};
     if (tagsArray && tagsArray.length) {
       tagsArray.forEach(([key, value]) => (metricTags[key] = value));
     }

--- a/src/wavefrontHistogram.js
+++ b/src/wavefrontHistogram.js
@@ -1,7 +1,4 @@
-import {
-  WavefrontHistogramImpl,
-  Distribution
-} from '../../wavefront-sdk-javascript/src/index';
+import { WavefrontHistogramImpl, Distribution } from 'wavefront-sdk-javascript';
 import TaggedRegistry from './registry';
 const metrics = require('metrics');
 

--- a/src/wavefrontHistogram.js
+++ b/src/wavefrontHistogram.js
@@ -1,9 +1,9 @@
-const metrics = require('metrics');
-const histogramImpl = require('../../wavefront-sdk-javascript/src/index')
-  .histogramImpl;
-const Distribution = require('../../wavefront-sdk-javascript/src/index')
-  .histogramImpl.Distribution;
-const TaggedRegistry = require('./registry');
+import metrics from 'metrics';
+import {
+  WavefrontHistogramImpl,
+  Distribution
+} from '../../wavefront-sdk-javascript/src/index';
+import TaggedRegistry from './registry';
 
 /**
  *
@@ -38,12 +38,12 @@ function get(name, registry) {
 class WavefrontHistogram extends metrics.Histogram {
   constructor(clockMillis = null) {
     super();
-    this._delegate = new histogramImpl.WavefrontHistogramImpl(clockMillis);
+    this._delegate = new WavefrontHistogramImpl(clockMillis);
     this.update = value => this._delegate.update(value);
   }
 
   clear() {
-    this._delegate = histogramImpl.WavefrontHistogramImpl();
+    this._delegate = WavefrontHistogramImpl();
   }
 
   getCount() {
@@ -87,8 +87,4 @@ class WavefrontHistogram extends metrics.Histogram {
   }
 }
 
-module.exports = {
-  wavefrontHistogram,
-  get,
-  WavefrontHistogram
-};
+export { wavefrontHistogram, get, WavefrontHistogram };

--- a/src/wavefrontHistogram.js
+++ b/src/wavefrontHistogram.js
@@ -10,12 +10,12 @@ const wavefrontSDK = require('wavefront-sdk-javascript');
  * @param tags
  * @return {WavefrontHistogram}
  */
-function wavefrontHistogram(registry, name, tags = null) {
-  if (!name) {
+function registerHistogram(registry, name, tags = null) {
+  if (!name || !name.trim()) {
     throw 'invalid counter name';
   }
 
-  let histogram = new WavefrontHistogram();
+  const histogram = new WavefrontHistogram();
   if (registry instanceof TaggedRegistry) {
     name = utils.encodeKey(name, tags);
   }
@@ -34,14 +34,17 @@ class WavefrontHistogram extends metrics.Histogram {
   constructor(clockMillis = null) {
     super();
     this._delegate = new wavefrontSDK.WavefrontHistogramImpl(clockMillis);
-    this.update = value => this._delegate.update(value);
+  }
+
+  update(value, timestamp = null) {
+    this._delegate.update(value);
   }
 
   /**
    * Instantiate brand new WavefrontHistogramImpl().
    */
   clear() {
-    this._delegate = wavefrontSDK.WavefrontHistogramImpl();
+    this._delegate = new wavefrontSDK.WavefrontHistogramImpl();
   }
 
   getCount() {
@@ -85,4 +88,4 @@ class WavefrontHistogram extends metrics.Histogram {
   }
 }
 
-export { wavefrontHistogram, WavefrontHistogram };
+export { registerHistogram, WavefrontHistogram };

--- a/src/wavefrontHistogram.js
+++ b/src/wavefrontHistogram.js
@@ -1,0 +1,94 @@
+const metrics = require('metrics');
+const histogramImpl = require('../../wavefront-sdk-javascript/src/index')
+  .histogramImpl;
+const Distribution = require('../../wavefront-sdk-javascript/src/index')
+  .histogramImpl.Distribution;
+const TaggedRegistry = require('./registry');
+
+/**
+ *
+ * @param {TaggedRegistry} registry
+ * @param name
+ * @param tags
+ * @return {WavefrontHistogram}
+ */
+function wavefrontHistogram(registry, name, tags = null) {
+  // TODO: not tagged registry
+  if (!name) {
+    throw 'invalid counter name';
+  }
+  let histogram = new WavefrontHistogram();
+  registry.addMetric(name, histogram);
+  return histogram;
+}
+
+/**
+ * Get Wavefront Histogram with the given name is in registry.
+ * Return null if the given name doesn't exist
+ */
+function get(name, registry) {
+  // TODO: delete function
+  // TODO: not tagged registry
+  if (registry.hasHistogram(name)) {
+    return registry.histogram(name);
+  }
+  return null;
+}
+
+class WavefrontHistogram extends metrics.Histogram {
+  constructor(clockMillis = null) {
+    super();
+    this._delegate = new histogramImpl.WavefrontHistogramImpl(clockMillis);
+    this.update = value => this._delegate.update(value);
+  }
+
+  clear() {
+    this._delegate = histogramImpl.WavefrontHistogramImpl();
+  }
+
+  getCount() {
+    return this._delegate.getCount();
+  }
+
+  getSum() {
+    return this._delegate.getSum();
+  }
+
+  getMax() {
+    return this._delegate.getMax();
+  }
+
+  getMin() {
+    return this._delegate.getMin();
+  }
+
+  getMean() {
+    return this._delegate.getMean();
+  }
+
+  getStddev() {
+    return this._delegate.stdDev();
+  }
+
+  // TODO
+  getVar() {}
+  getSnapshot() {}
+
+  /**
+   *
+   * @returns {Distribution[]}
+   */
+  getDistribution() {
+    return this._delegate.flushDistributions();
+  }
+
+  getCurrentMinuteDistribution() {
+    return this._delegate.getCurrentBin().toDistribution();
+  }
+}
+
+module.exports = {
+  wavefrontHistogram,
+  get,
+  WavefrontHistogram
+};

--- a/src/wavefrontHistogram.js
+++ b/src/wavefrontHistogram.js
@@ -1,9 +1,9 @@
-import metrics from 'metrics';
 import {
   WavefrontHistogramImpl,
   Distribution
 } from '../../wavefront-sdk-javascript/src/index';
 import TaggedRegistry from './registry';
+const metrics = require('metrics');
 
 /**
  *

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,0 +1,39 @@
+const expect = require('chai').expect;
+const describe = require('mocha').describe;
+const it = require('mocha').it;
+const Util = require('../src/util');
+
+describe('encodeKey', function() {
+  it('Test encode function on valid tag format', function() {
+    let key11 = Util.encodeKey('http.request', { key1: 'val1' });
+    expect(key11).to.equal('http.request-tags=[["key1","val1"]]');
+
+    let key12 = Util.encodeKey('http.request', { key1: 'val2' });
+    expect(key12).to.equal('http.request-tags=[["key1","val2"]]');
+
+    let key = Util.encodeKey('http.request');
+    expect(key).to.equal('http.request');
+  });
+
+  it('Test encode function on invalid tag format', function() {
+    expect(function() {
+      Util.encodeKey('http.request', '{"key1":"val1"}');
+    }).throw(
+      'Wrong Tags datatype sent to the API. Expected: Object. Actual: String'
+    );
+  });
+});
+
+describe('decodeKey', function() {
+  it('Test Decode function', function() {
+    let key11 = 'http.request-tags={"key1":"val1","key2":"val2"}';
+    let decodedKey = Util.decodeKey(key11);
+    expect(decodedKey[0]).to.equal('http.request');
+    expect(decodedKey[1]).to.equal('{"key1":"val1","key2":"val2"}');
+
+    let key = 'http.request';
+    decodedKey = Util.decodeKey(key);
+    expect(decodedKey[0]).to.equal('http.request');
+    expect(decodedKey[1]).to.equal(null);
+  });
+});

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,23 +1,24 @@
-const expect = require('chai').expect;
-const describe = require('mocha').describe;
-const it = require('mocha').it;
-const Util = require('../src/util');
+import { expect } from 'chai';
+import { describe } from 'mocha';
+import { it } from 'mocha';
+
+import util from '../src/util';
 
 describe('encodeKey', function() {
   it('Test encode function on valid tag format', function() {
-    let key11 = Util.encodeKey('http.request', { key1: 'val1' });
+    let key11 = util.encodeKey('http.request', { key1: 'val1' });
     expect(key11).to.equal('http.request-tags=[["key1","val1"]]');
 
-    let key12 = Util.encodeKey('http.request', { key1: 'val2' });
+    let key12 = util.encodeKey('http.request', { key1: 'val2' });
     expect(key12).to.equal('http.request-tags=[["key1","val2"]]');
 
-    let key = Util.encodeKey('http.request');
+    let key = util.encodeKey('http.request');
     expect(key).to.equal('http.request');
   });
 
   it('Test encode function on invalid tag format', function() {
     expect(function() {
-      Util.encodeKey('http.request', '{"key1":"val1"}');
+      util.encodeKey('http.request', '{"key1":"val1"}');
     }).throw(
       'Wrong Tags datatype sent to the API. Expected: Object. Actual: String'
     );
@@ -27,12 +28,12 @@ describe('encodeKey', function() {
 describe('decodeKey', function() {
   it('Test Decode function', function() {
     let key11 = 'http.request-tags={"key1":"val1","key2":"val2"}';
-    let decodedKey = Util.decodeKey(key11);
+    let decodedKey = util.decodeKey(key11);
     expect(decodedKey[0]).to.equal('http.request');
     expect(decodedKey[1]).to.equal('{"key1":"val1","key2":"val2"}');
 
     let key = 'http.request';
-    decodedKey = Util.decodeKey(key);
+    decodedKey = util.decodeKey(key);
     expect(decodedKey[0]).to.equal('http.request');
     expect(decodedKey[1]).to.equal(null);
   });


### PR DESCRIPTION
This PR includes the basic features of Wavefront tier 2 Sender SDK, which includes:
1. wavefront metrics reporter
2. native wavefront histogram support
3. an abstraction that supports tagging at the host level

Testing is done through:
1. Unit tests for utility functions
2. End-to-end testing on the `tracing` server

It also includes an example file to test upon. 